### PR TITLE
Anpassung Icon Dashboard

### DIFF
--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -22,7 +22,7 @@
         <div class="card-body d-flex flex-wrap">
             <div class="align-self-center text-center user-icon rounded-circle mr-3 bg-primary text-white" style="width: 50px; height: 50px;">
                 <div class="d-flex align-items-center text-center h-100">
-                    <i class="far fa-user fa-2x mx-auto"></i>
+                    <i class="fas fa-user fa-2x mx-auto"></i>
                 </div>
             </div>
             <div class="align-self-center pr-5 mr-auto">


### PR DESCRIPTION
Selbe Ausgangslage wie im ServiceCenter. Siehe [hier](https://github.com/SchulIT/servicecenter/pull/35) & [hier](https://github.com/SchulIT/servicecenter/pull/36).


## Ansicht
Vorher:
<img width="421" alt="Bildschirmfoto 2021-08-31 um 08 11 39" src="https://user-images.githubusercontent.com/74987472/131464966-161e122e-7b4f-41c7-9a14-5f83bcb8d8b7.png">
Nachher:
<img width="428" alt="Bildschirmfoto 2021-08-31 um 08 11 29" src="https://user-images.githubusercontent.com/74987472/131464963-6dfa7a18-086c-46d0-b5c8-243c1199d1f5.png">